### PR TITLE
Catch also branches including dots

### DIFF
--- a/flexprompt.lua
+++ b/flexprompt.lua
@@ -1430,7 +1430,7 @@ function flexprompt.get_git_status()
 
     line = file:read("*l")
     if line then
-        unpublished = not line:find("^## ([^.]+)%.%.%.")
+        unpublished = not line:find("^## (.+)%.%.%.")
     end
 
     while true do


### PR DESCRIPTION
A branch might have a name including a dot, like "v2.0".
This patch allows catching such branch names that before appeared as unlinked.