### PR TITLE
Skip npm package name if it matches folder name

### DIFF
--- a/flexprompt_modules.lua
+++ b/flexprompt_modules.lua
@@ -1279,7 +1279,7 @@ local function render_npm(args)
     local package_name = string.match(package_info, '"name"%s*:%s*"(%g-)"') or ""
     local package_version = string.match(package_info, '"version"%s*:%s*"(.-)"') or ""
 
-    local folder_name = get_folder_name(clink.get_cwd())
+    local folder_name = get_folder_name(os.getcwd())
     local smartname = flexprompt.parse_arg_keyword(args, "smartname")
     if smartname and package_name == folder_name then
         package_name = ""

--- a/flexprompt_modules.lua
+++ b/flexprompt_modules.lua
@@ -1257,7 +1257,8 @@ local function render_modmark(args)
 end
 
 --------------------------------------------------------------------------------
--- NPM MODULE:  {npm:color=color_name,alt_color_name}
+-- NPM MODULE:  {npm:smartname:color=color_name,alt_color_name}
+--  - smartname skips package name if it matches folder name.
 --  - color_name is a name like "green", or an sgr code like "38;5;60".
 --  - alt_color_name is optional; it is the text color in rainbow style.
 
@@ -1277,6 +1278,12 @@ local function render_npm(args)
 
     local package_name = string.match(package_info, '"name"%s*:%s*"(%g-)"') or ""
     local package_version = string.match(package_info, '"version"%s*:%s*"(.-)"') or ""
+
+    local folder_name = get_folder_name(clink.get_cwd())
+    local smartname = flexprompt.parse_arg_keyword(args, "smartname")
+    if smartname and package_name == folder_name then
+        package_name = ""
+    end
 
     local text = package_name .. "@" .. package_version
     text = flexprompt.append_text(flexprompt.get_module_symbol(), text)


### PR DESCRIPTION
Hi! 

First of all thanks for absolutely great work (everything you did around reviving the old `clink` which I have been using for long before I got here).
Secondly I wanted to propose a very simple change. I had this in my old setup already, so that whenever npm package name matches folder name (which is the case most of the time, at least from my experience) let's just skip it because it doesn't give any extra value.
I've hidden it behind a "feature flag" so that by default nothing changes, it has to be explicitly enabled. I find it very useful, feel free to comment.

**Edit**: forgot to include a simple demo (before and after accordingly):
![image](https://user-images.githubusercontent.com/2623329/204155123-d544e3c2-3e85-47dd-89f0-21d1345f3984.png)
